### PR TITLE
Sc 556/develop dashboard UI only

### DIFF
--- a/Chrono.xcodeproj/project.pbxproj
+++ b/Chrono.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		1E874396AD7AD77BFB8358EE /* Pods_Chrono.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6EA824E4FEB97E8DF52E5CE1 /* Pods_Chrono.framework */; };
 		47580FE626966D12002CF7AA /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47580FE526966D12002CF7AA /* Strings.swift */; };
 		47580FE826966D34002CF7AA /* Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47580FE726966D34002CF7AA /* Links.swift */; };
+		5368F3152777D378002343E4 /* Circuit Empty Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5368F3142777D378002343E4 /* Circuit Empty Page.swift */; };
 		E5CC3B74276C295500E25BF7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E5CC3B73276C295500E25BF7 /* GoogleService-Info.plist */; };
 		E5CC3B86276C388D00E25BF7 /* DarkModeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CC3B85276C388D00E25BF7 /* DarkModeModifier.swift */; };
 /* End PBXBuildFile section */
@@ -55,6 +56,7 @@
 		2176FA5421E9C0ECB29B8680 /* Pods-Chrono.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Chrono.debug.xcconfig"; path = "Target Support Files/Pods-Chrono/Pods-Chrono.debug.xcconfig"; sourceTree = "<group>"; };
 		47580FE526966D12002CF7AA /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		47580FE726966D34002CF7AA /* Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Links.swift; sourceTree = "<group>"; };
+		5368F3142777D378002343E4 /* Circuit Empty Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Circuit Empty Page.swift"; sourceTree = "<group>"; };
 		6EA824E4FEB97E8DF52E5CE1 /* Pods_Chrono.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Chrono.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AFB24C9EE1D9923B8113AEE /* Pods-Chrono.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Chrono.release.xcconfig"; path = "Target Support Files/Pods-Chrono/Pods-Chrono.release.xcconfig"; sourceTree = "<group>"; };
 		E5CC3B73276C295500E25BF7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			children = (
 				1B246ACF2679881A0062156B /* Circuits.swift */,
 				1B246ADB2679910F0062156B /* Circuit Row.swift */,
+				5368F3142777D378002343E4 /* Circuit Empty Page.swift */,
 			);
 			path = Circuits;
 			sourceTree = "<group>";
@@ -351,6 +354,7 @@
 				1B246ACC267987FB0062156B /* Onboarding.swift in Sources */,
 				1B246AD02679881A0062156B /* Circuits.swift in Sources */,
 				1B824B472681822100434070 /* SplashScreen.swift in Sources */,
+				5368F3152777D378002343E4 /* Circuit Empty Page.swift in Sources */,
 				47580FE826966D34002CF7AA /* Links.swift in Sources */,
 				47580FE626966D12002CF7AA /* Strings.swift in Sources */,
 				E5CC3B86276C388D00E25BF7 /* DarkModeModifier.swift in Sources */,
@@ -492,7 +496,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"Chrono/Preview Content\"";
-				DEVELOPMENT_TEAM = LL6476HKHT;
+				DEVELOPMENT_TEAM = 4Z782ZN82J;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Chrono/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -515,7 +519,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"Chrono/Preview Content\"";
-				DEVELOPMENT_TEAM = LL6476HKHT;
+				DEVELOPMENT_TEAM = 4Z782ZN82J;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = Chrono/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;

--- a/Chrono.xcodeproj/project.pbxproj
+++ b/Chrono.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		47580FE626966D12002CF7AA /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47580FE526966D12002CF7AA /* Strings.swift */; };
 		47580FE826966D34002CF7AA /* Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47580FE726966D34002CF7AA /* Links.swift */; };
 		5368F3152777D378002343E4 /* Circuit Empty Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5368F3142777D378002343E4 /* Circuit Empty Page.swift */; };
+		5368F31A277BAC09002343E4 /* CircuitObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5368F319277BAC09002343E4 /* CircuitObject.swift */; };
 		E5CC3B74276C295500E25BF7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = E5CC3B73276C295500E25BF7 /* GoogleService-Info.plist */; };
 		E5CC3B86276C388D00E25BF7 /* DarkModeModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5CC3B85276C388D00E25BF7 /* DarkModeModifier.swift */; };
 /* End PBXBuildFile section */
@@ -57,6 +58,7 @@
 		47580FE526966D12002CF7AA /* Strings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		47580FE726966D34002CF7AA /* Links.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Links.swift; sourceTree = "<group>"; };
 		5368F3142777D378002343E4 /* Circuit Empty Page.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Circuit Empty Page.swift"; sourceTree = "<group>"; };
+		5368F319277BAC09002343E4 /* CircuitObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircuitObject.swift; sourceTree = "<group>"; };
 		6EA824E4FEB97E8DF52E5CE1 /* Pods_Chrono.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Chrono.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		8AFB24C9EE1D9923B8113AEE /* Pods-Chrono.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Chrono.release.xcconfig"; path = "Target Support Files/Pods-Chrono/Pods-Chrono.release.xcconfig"; sourceTree = "<group>"; };
 		E5CC3B73276C295500E25BF7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -97,6 +99,7 @@
 		1B246AB1267982130062156B /* Chrono */ = {
 			isa = PBXGroup;
 			children = (
+				5368F317277BABEE002343E4 /* Util */,
 				1B6F5358268449A60020D3C3 /* ViewRouter.swift */,
 				1B824B462681822100434070 /* SplashScreen.swift */,
 				1B246AD926798AC10062156B /* TabBar.swift */,
@@ -195,6 +198,22 @@
 				8AFB24C9EE1D9923B8113AEE /* Pods-Chrono.release.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		5368F317277BABEE002343E4 /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				5368F318277BABF5002343E4 /* Objects */,
+			);
+			path = Util;
+			sourceTree = "<group>";
+		};
+		5368F318277BABF5002343E4 /* Objects */ = {
+			isa = PBXGroup;
+			children = (
+				5368F319277BAC09002343E4 /* CircuitObject.swift */,
+			);
+			path = Objects;
 			sourceTree = "<group>";
 		};
 		A23B7BACDBB6243064AC678B /* Frameworks */ = {
@@ -356,6 +375,7 @@
 				1B824B472681822100434070 /* SplashScreen.swift in Sources */,
 				5368F3152777D378002343E4 /* Circuit Empty Page.swift in Sources */,
 				47580FE826966D34002CF7AA /* Links.swift in Sources */,
+				5368F31A277BAC09002343E4 /* CircuitObject.swift in Sources */,
 				47580FE626966D12002CF7AA /* Strings.swift in Sources */,
 				E5CC3B86276C388D00E25BF7 /* DarkModeModifier.swift in Sources */,
 				1B246AD826798A990062156B /* NavigationBar.swift in Sources */,

--- a/Chrono/Circuits/Circuit Empty Page.swift
+++ b/Chrono/Circuits/Circuit Empty Page.swift
@@ -22,6 +22,7 @@ struct Circuit_Empty_Page: View {
         .background(Color("Plum"))
         .cornerRadius(20, antialiased: true)
         .frame(maxWidth: .infinity)
+        .shadow(color: .black, radius: 3, x: 0, y: 3)
     }
 }
 
@@ -29,6 +30,5 @@ struct Circuit_Empty_Page_Previews: PreviewProvider {
     static var previews: some View {
         Circuit_Empty_Page()
             .preferredColorScheme(.dark)
-//            .previewLayout(.sizeThatFits)
     }
 }

--- a/Chrono/Circuits/Circuit Empty Page.swift
+++ b/Chrono/Circuits/Circuit Empty Page.swift
@@ -11,17 +11,19 @@ struct Circuit_Empty_Page: View{
     
     var body: some View{
         HStack{
-            
             Image(systemName: "plus.circle")
                 .foregroundColor(Color("Mustard"))
                 .font(.largeTitle)
                 .padding()
             
             Text("Create a Circuit")
+            Spacer()
         }
-        .padding()
-        .background(Color("Plum"))
-        .cornerRadius(20, antialiased: true)
+            .padding()
+            .background(Color("Plum"))
+            .cornerRadius(20, antialiased: true)
+            .frame(maxWidth: .infinity)
+            
     }
 }
 
@@ -29,6 +31,6 @@ struct Circuit_Empty_Page_Previews: PreviewProvider{
     static var previews: some View{
         Circuit_Empty_Page()
             .preferredColorScheme(.dark)
-            .previewLayout(.sizeThatFits)
+//            .previewLayout(.sizeThatFits)
     }
 }

--- a/Chrono/Circuits/Circuit Empty Page.swift
+++ b/Chrono/Circuits/Circuit Empty Page.swift
@@ -1,0 +1,34 @@
+//
+//  Circuit Empty Page.swift
+//  Chrono
+//
+//  Created by Hari Govind on 2021-12-25.
+//
+
+import SwiftUI
+
+struct Circuit_Empty_Page: View{
+    
+    var body: some View{
+        HStack{
+            
+            Image(systemName: "plus.circle")
+                .foregroundColor(Color("Mustard"))
+                .font(.largeTitle)
+                .padding()
+            
+            Text("Create a Circuit")
+        }
+        .padding()
+        .background(Color("Plum"))
+        .cornerRadius(20, antialiased: true)
+    }
+}
+
+struct Circuit_Empty_Page_Previews: PreviewProvider{
+    static var previews: some View{
+        Circuit_Empty_Page()
+            .preferredColorScheme(.dark)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Chrono/Circuits/Circuit Empty Page.swift
+++ b/Chrono/Circuits/Circuit Empty Page.swift
@@ -7,28 +7,26 @@
 
 import SwiftUI
 
-struct Circuit_Empty_Page: View{
-    
-    var body: some View{
-        HStack{
+struct Circuit_Empty_Page: View {
+    var body: some View {
+        HStack {
             Image(systemName: "plus.circle")
                 .foregroundColor(Color("Mustard"))
                 .font(.largeTitle)
                 .padding()
-            
+
             Text("Create a Circuit")
             Spacer()
         }
-            .padding()
-            .background(Color("Plum"))
-            .cornerRadius(20, antialiased: true)
-            .frame(maxWidth: .infinity)
-            
+        .padding()
+        .background(Color("Plum"))
+        .cornerRadius(20, antialiased: true)
+        .frame(maxWidth: .infinity)
     }
 }
 
-struct Circuit_Empty_Page_Previews: PreviewProvider{
-    static var previews: some View{
+struct Circuit_Empty_Page_Previews: PreviewProvider {
+    static var previews: some View {
         Circuit_Empty_Page()
             .preferredColorScheme(.dark)
 //            .previewLayout(.sizeThatFits)

--- a/Chrono/Circuits/Circuit Row.swift
+++ b/Chrono/Circuits/Circuit Row.swift
@@ -28,9 +28,14 @@ struct Circuit_Row: View {
                     Image(systemName: "line.horizontal.3")
                         .resizable()
                         .frame(width: 10, height: 15, alignment: .center)
+                        
+                    
                 }
+                .padding(.trailing)
+                
 
                 Text("\(sets) Sets")
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack {
                     BottomLabel(restTime: 50)
@@ -41,8 +46,10 @@ struct Circuit_Row: View {
                 .padding(.top)
             }
         }
-        .padding()
+        .background(Color("Plum"))
+        .cornerRadius(20, antialiased: true)
     }
+    
 }
 
 private struct BottomLabel: View {
@@ -61,6 +68,6 @@ struct Circuit_Row_Previews: PreviewProvider {
     static var previews: some View {
         Circuit_Row()
             .preferredColorScheme(.dark)
-            .previewLayout(.sizeThatFits)
+//            .previewLayout(.sizeThatFits)
     }
 }

--- a/Chrono/Circuits/Circuit Row.swift
+++ b/Chrono/Circuits/Circuit Row.swift
@@ -49,6 +49,7 @@ struct Circuit_Row: View {
         }
         .background(Color("Plum"))
         .cornerRadius(20, antialiased: true)
+        .shadow(color: .black, radius: 3, x: 0, y: 3)
     }
 }
 
@@ -92,6 +93,5 @@ struct Circuit_Row_Previews: PreviewProvider {
     static var previews: some View {
         Circuit_Row()
             .preferredColorScheme(.dark)
-//            .previewLayout(.sizeThatFits)
     }
 }

--- a/Chrono/Circuits/Circuit Row.swift
+++ b/Chrono/Circuits/Circuit Row.swift
@@ -8,15 +8,15 @@
 import SwiftUI
 
 struct Circuit_Row: View {
-    @State var sets = 5
     @State var circuitName = "Push ups"
+    @State var sets = 5
     @State var restTime = 50
     @State var workTime = 25
-    @State var workoutImg = Image("ic_abs")
+    @State var workoutImg = "ic_abs"
 
     var body: some View {
         HStack {
-            workoutImg
+            Image(workoutImg)
                 .resizable()
                 .frame(width: 80, height: 80, alignment: .center)
                 .padding()
@@ -32,11 +32,8 @@ struct Circuit_Row: View {
                     Image(systemName: "line.horizontal.3")
                         .resizable()
                         .frame(width: 10, height: 15, alignment: .center)
-                        
-                    
                 }
-                    .padding(.trailing)
-                
+                .padding(.trailing)
 
                 Text("\(sets) Sets")
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -53,7 +50,6 @@ struct Circuit_Row: View {
         .background(Color("Plum"))
         .cornerRadius(20, antialiased: true)
     }
-    
 }
 
 private struct RestBottomLabel: View {
@@ -72,7 +68,7 @@ private struct WorkBottomLabel: View {
     var label = "Work"
     var img = Image(systemName: "clock")
     var body: some View {
-        HStack{
+        HStack {
             BottomLabel(value: workTime, name: label, img: img)
         }
     }

--- a/Chrono/Circuits/Circuit Row.swift
+++ b/Chrono/Circuits/Circuit Row.swift
@@ -9,17 +9,21 @@ import SwiftUI
 
 struct Circuit_Row: View {
     @State var sets = 5
+    @State var circuitName = "Push ups"
+    @State var restTime = 50
+    @State var workTime = 25
+    @State var workoutImg = Image("ic_abs")
 
     var body: some View {
         HStack {
-            Image(systemName: "heart.fill")
+            workoutImg
                 .resizable()
                 .frame(width: 80, height: 80, alignment: .center)
                 .padding()
 
             VStack {
                 HStack {
-                    Text("Jump Rope Warmup")
+                    Text("\(circuitName)")
                         .bold()
                         .font(.body)
 
@@ -31,16 +35,16 @@ struct Circuit_Row: View {
                         
                     
                 }
-                .padding(.trailing)
+                    .padding(.trailing)
                 
 
                 Text("\(sets) Sets")
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 HStack {
-                    BottomLabel(restTime: 50)
+                    RestBottomLabel(restTime: 50)
                         .padding(.trailing)
-                    BottomLabel()
+                    WorkBottomLabel()
                     Spacer()
                 }
                 .padding(.top)
@@ -52,14 +56,38 @@ struct Circuit_Row: View {
     
 }
 
-private struct BottomLabel: View {
-    @State var restTime = 10
+private struct RestBottomLabel: View {
+    @State var restTime = 25
+    var label = "Rest"
+    var img = Image("timer_black")
     var body: some View {
         HStack {
-            Image(systemName: "line.horizontal.3")
+            BottomLabel(value: restTime, name: label, img: img)
+        }
+    }
+}
+
+private struct WorkBottomLabel: View {
+    @State var workTime = 25
+    var label = "Work"
+    var img = Image(systemName: "clock")
+    var body: some View {
+        HStack{
+            BottomLabel(value: workTime, name: label, img: img)
+        }
+    }
+}
+
+private struct BottomLabel: View {
+    @State var value = 10
+    @State var name = "Work"
+    @State var img = Image(systemName: "line.horizontal.3")
+    var body: some View {
+        HStack {
+            img
                 .resizable()
-                .frame(width: 10, height: 15, alignment: .center)
-            Text("Rest: \(restTime)s")
+                .frame(width: 15, height: 15, alignment: .center)
+            Text("\(name): \(value)s")
         }
     }
 }

--- a/Chrono/Circuits/Circuits.swift
+++ b/Chrono/Circuits/Circuits.swift
@@ -8,10 +8,17 @@
 import SwiftUI
 
 struct Circuits: View {
+    let circuit1 = CircuitObject(circuitName: "eating", sets: 5, restTime: 50, workTime: 25, workoutImg: "ic_abs")
+    let circuit2 = CircuitObject(circuitName: "running", sets: 5, restTime: 50, workTime: 25, workoutImg: "ic_arm")
+
     var body: some View {
-        VStack {
+        let tempList: [CircuitObject] = [circuit1, circuit2]
+        VStack(spacing: 10) {
             Circuit_Empty_Page()
-            Circuit_Row()
+            ForEach(0 ... 1, id: \.self) {
+                Circuit_Row(circuitName: tempList[$0].circuitName, sets: tempList[$0].sets, restTime: tempList[$0].restTime, workTime: tempList[$0].workTime, workoutImg: tempList[$0].workoutImg)
+            }
+
             Spacer()
         }
     }

--- a/Chrono/Circuits/Circuits.swift
+++ b/Chrono/Circuits/Circuits.swift
@@ -10,7 +10,8 @@ import SwiftUI
 struct Circuits: View {
     var body: some View {
         VStack {
-            Circuit_Row()
+            Circuit_Empty_Page()
+//            Circuit_Row()
             Spacer()
         }
     }

--- a/Chrono/Circuits/Circuits.swift
+++ b/Chrono/Circuits/Circuits.swift
@@ -11,7 +11,7 @@ struct Circuits: View {
     var body: some View {
         VStack {
             Circuit_Empty_Page()
-//            Circuit_Row()
+            Circuit_Row()
             Spacer()
         }
     }

--- a/Chrono/Util/Objects/CircuitObject.swift
+++ b/Chrono/Util/Objects/CircuitObject.swift
@@ -1,0 +1,16 @@
+//
+//  CircuitObject.swift
+//  Chrono
+//
+//  Created by Hari Govind on 2021-12-28.
+//
+
+import Foundation
+
+struct CircuitObject {
+    var circuitName = "Random Name"
+    var sets = 5
+    var restTime = 50
+    var workTime = 25
+    var workoutImg = "ic_abs"
+}


### PR DESCRIPTION
**Shortcut Story:**
https://app.shortcut.com/chrono/story/556/develop-dashboard-ui-only


**What does this PR solve?**
Creates the New UI for the timer dashboard.

![Screenshot 2021-12-30 at 15 34 53](https://user-images.githubusercontent.com/22647864/147786444-680ddd1d-2cda-411c-9638-9daee6dee908.jpeg)



**List the steps to take to replicate the behavior introduced by this PR**
Open the app, and navigate to timer


**List any known issues that this PR brings about**
Added the empty card and sample custom card, we can select which one to use when the logic is completed. 
Only supports timed workout, will need to update this once we have a design for rep based workouts.
Background color of the app is the default black, this needs to be changed to Velvet i believe. Because the background is black, the drop shadow cannot be seen, but it exits trust.

**What's something funny/stupid that happened when working on this story?**



**Other information**



**Please check if the PR fulfills these requirements**
- [x] The commit messages follows our guidelines
- [x] All errors and warnings have been taken care of
